### PR TITLE
Fix small bugs

### DIFF
--- a/compare_mt/compare_ll_main.py
+++ b/compare_mt/compare_ll_main.py
@@ -24,6 +24,8 @@ def print_word_likelihood_report(ref, lls, bucket_type='freq',
   label_set: the permissible set of labels when using "label" as a bucket type
   case_insensitive: A boolean specifying whether to turn on the case insensitive option
   """
+  case_insensitive = True if case_insensitive == 'True' else False
+
   bucketer = bucketers.create_word_bucketer_from_profile(bucket_type=bucket_type,
                                                        freq_count_file=freq_count_file,
                                                        freq_corpus_file=freq_corpus_file,

--- a/compare_mt/compare_mt_main.py
+++ b/compare_mt/compare_mt_main.py
@@ -28,7 +28,10 @@ def generate_score_report(ref, outs,
     compare_directions: A string specifying which systems to compare
     case_insensitive: A boolean specifying whether to turn on the case insensitive option
   """
-  scorer = scorers.create_scorer_from_profile(score_type)
+  bootstrap = int(bootstrap)
+  case_insensitive = True if case_insensitive == 'True' else False
+
+  scorer = scorers.create_scorer_from_profile(score_type, case_insensitive=case_insensitive)
 
   scores, strs = zip(*[scorer.score_corpus(ref, out) for out in outs])
 
@@ -37,7 +40,7 @@ def generate_score_report(ref, outs,
     for i in range(len(scores)):
       for j in range(i+1, len(scores)):
         direcs.append( (i,j) )
-    wins, sys_stats = sign_utils.eval_with_paired_bootstrap(ref, outs, scorer, direcs, num_samples=int(bootstrap))
+    wins, sys_stats = sign_utils.eval_with_paired_bootstrap(ref, outs, scorer, direcs, num_samples=bootstrap)
     wins = list(zip(direcs, wins))
   else:
     wins = sys_stats = direcs = None
@@ -72,6 +75,8 @@ def generate_word_accuracy_report(ref, outs,
     out_labels: output labels. must be specified if ref_labels is specified.
     case_insensitive: A boolean specifying whether to turn on the case insensitive option
   """
+  case_insensitive = True if case_insensitive == 'True' else False
+
   if out_labels is not None:
     out_labels = arg_utils.parse_files(out_labels)
     if len(out_labels) != len(outs):
@@ -120,6 +125,8 @@ def generate_src_word_accuracy_report(src, ref, outs, ref_align, out_aligns,
     src_labels: either a filename of a file full of source labels, or a list of strings corresponding to `ref`.
     case_insensitive: A boolean specifying whether to turn on the case insensitive option
   """
+  case_insensitive = True if case_insensitive == 'True' else False
+  
   if not src or not ref_align or not out_aligns:
     raise ValueError("Must specify the source and the alignment files when performing source analysis.")
 
@@ -127,7 +134,8 @@ def generate_src_word_accuracy_report(src, ref, outs, ref_align, out_aligns,
                                                          freq_count_file=freq_count_file,
                                                          freq_corpus_file=freq_corpus_file,
                                                          freq_data=src,
-                                                         label_set=label_set)
+                                                         label_set=label_set,
+                                                         case_insensitive=case_insensitive)
   src_labels = corpus_utils.load_tokens(src_labels) if type(src_labels) == str else src_labels
   matches = [bucketer.calc_source_bucketed_matches(src, ref, out, ref_align, out_align, src_labels=src_labels) for out, out_align in zip(outs, out_aligns)]
 
@@ -152,6 +160,7 @@ def generate_sentence_bucketed_report(ref, outs,
     score_measure: If using 'score' as either bucket_type or statistic_type, which scorer to use
     case_insensitive: A boolean specifying whether to turn on the case insensitive option
   """
+  case_insensitive = True if case_insensitive == 'True' else False
 
   bucketer = bucketers.create_sentence_bucketer_from_profile(bucket_type, score_type=score_measure, case_insensitive=case_insensitive)
   bcs = [bucketer.create_bucketed_corpus(out, ref=ref) for out in outs]
@@ -202,6 +211,10 @@ def generate_ngram_report(ref, outs,
     compare_directions: A string specifying which systems to compare
     case_insensitive: A boolean specifying whether to turn on the case insensitive option
   """
+  min_ngram_length, max_ngram_length, report_length = int(min_ngram_length), int(max_ngram_length), int(report_length)
+  alpha = float(alpha)
+  case_insensitive = True if case_insensitive == 'True' else False
+
   if out_labels is not None:
     out_labels = arg_utils.parse_files(out_labels)
     if len(out_labels) != len(outs):
@@ -267,6 +280,8 @@ def generate_sentence_examples(ref, outs,
     compare_directions: A string specifying which systems to compare
     case_insensitive: A boolean specifying whether to turn on the case insensitive option
   """
+  report_length = int(report_length)
+  case_insensitive = True if case_insensitive == 'True' else False
     
   scorer = scorers.create_scorer_from_profile(score_type, case_insensitive=case_insensitive)
 


### PR DESCRIPTION
Right now setting integer or real-valued parameters (e.g. --compare_sentence_examples report_length=50) would raise errors. 