### PR TITLE
Bump up version number to 0.2 to fix pypi error

### DIFF
--- a/compare_mt/__init__.py
+++ b/compare_mt/__init__.py
@@ -9,4 +9,4 @@ import compare_mt.arg_utils
 import compare_mt.print_utils
 
 
-__version__ = "0.1"
+__version__ = "0.2"


### PR DESCRIPTION
Apparently PyPI doesn't allow reuploading the same version of a package that was deleted (in this case I created and deleted the compare-mt package for testing purposes).

Changing the version number to 0.2 should circumvent this issue.