### PR TITLE
Add Meteor scorer

### DIFF
--- a/compare_mt/compare_mt_main.py
+++ b/compare_mt/compare_mt_main.py
@@ -16,6 +16,7 @@ from compare_mt import formatting
 def generate_score_report(ref, outs,
                        score_type='bleu',
                        bootstrap=0,
+                       meteor_directory=None, options=None,
                        case_insensitive=False):
   """
   Generate a report comparing overall scores of system(s) in both plain text and graphs.
@@ -31,7 +32,7 @@ def generate_score_report(ref, outs,
   bootstrap = int(bootstrap)
   case_insensitive = True if case_insensitive == 'True' else False
 
-  scorer = scorers.create_scorer_from_profile(score_type, case_insensitive=case_insensitive)
+  scorer = scorers.create_scorer_from_profile(score_type, case_insensitive=case_insensitive, meteor_directory=meteor_directory, options=options)
 
   scores, strs = zip(*[scorer.score_corpus(ref, out) for out in outs])
 

--- a/compare_mt/corpus_utils.py
+++ b/compare_mt/corpus_utils.py
@@ -17,3 +17,16 @@ def load_nums(filename):
 
 def lower(inp):
   return inp.lower() if type(inp) == str else [lower(x) for x in inp]
+
+def list2str(l):
+  string = ''
+  for i, s in enumerate(l):
+    string = string + ' ' + str(s) if i != 0 else string + str(s)
+  return string
+  
+def write_tokens(f, ls):
+  for i, l in enumerate(ls):
+    string = list2str(l)
+    string = '\n' + string if i != 0 else string
+    f.write(string)
+  return string

--- a/compare_mt/corpus_utils.py
+++ b/compare_mt/corpus_utils.py
@@ -24,9 +24,10 @@ def list2str(l):
     string = string + ' ' + str(s) if i != 0 else string + str(s)
   return string
   
-def write_tokens(f, ls):
-  for i, l in enumerate(ls):
-    string = list2str(l)
-    string = '\n' + string if i != 0 else string
-    f.write(string)
+def write_tokens(filename, ls):
+  with open(filename, 'w') as f:
+    for i, l in enumerate(ls):
+      string = list2str(l)
+      string = '\n' + string if i != 0 else string
+      f.write(string)
   return string


### PR DESCRIPTION
Sample usage:

`compare-mt example/ted.ref.eng example/ted.sys1.eng example/ted.sys2.eng --compare_scores 'score_type=meteor,meteor_directory={meteor_directory},options=-l en -norm' `

Using sufficient statistics to calculate the METEOR score is a lot harder than I expected, would figure that out later.