### PR TITLE
Added ability to name analyses

### DIFF
--- a/compare_mt/compare_mt_main.py
+++ b/compare_mt/compare_mt_main.py
@@ -17,7 +17,7 @@ def generate_score_report(ref, outs,
                        score_type='bleu',
                        bootstrap=0, prob_thresh=0.05,
                        meteor_directory=None, options=None,
-                       caption=None, 
+                       title=None, 
                        case_insensitive=False):
   """
   Generate a report comparing overall scores of system(s) in both plain text and graphs.
@@ -31,7 +31,7 @@ def generate_score_report(ref, outs,
     meteor_directory: Path to the directory of the METEOR code
     options: Options when using external program
     compare_directions: A string specifying which systems to compare 
-    caption: A string specifying the caption of the printed table
+    title: A string specifying the caption of the printed table
     case_insensitive: A boolean specifying whether to turn on the case insensitive option
   """
   bootstrap = int(bootstrap)
@@ -54,7 +54,7 @@ def generate_score_report(ref, outs,
 
   reporter = reporters.ScoreReport(scorer=scorer, scores=scores, strs=strs, 
                                    wins=wins, sys_stats=sys_stats, prob_thresh=prob_thresh, 
-                                   caption=caption)
+                                   title=title)
   reporter.generate_report(output_fig_file=f'score-{score_type}-{bootstrap}',
                            output_fig_format='pdf', 
                            output_directory='outputs')
@@ -65,7 +65,7 @@ def generate_word_accuracy_report(ref, outs,
                           freq_count_file=None, freq_corpus_file=None,
                           label_set=None,
                           ref_labels=None, out_labels=None,
-                          caption=None,
+                          title=None,
                           case_insensitive=False):
   """
   Generate a report comparing the word accuracy in both plain text and graphs.
@@ -83,7 +83,7 @@ def generate_word_accuracy_report(ref, outs,
     freq_count_file: An alternative to freq_corpus that uses a count file in "word\tfreq" format.
     ref_labels: either a filename of a file full of reference labels, or a list of strings corresponding to `ref`.
     out_labels: output labels. must be specified if ref_labels is specified.
-    caption: A string specifying the caption of the printed table
+    title: A string specifying the caption of the printed table
     case_insensitive: A boolean specifying whether to turn on the case insensitive option
   """
   case_insensitive = True if case_insensitive == 'True' else False
@@ -106,7 +106,7 @@ def generate_word_accuracy_report(ref, outs,
   
   reporter = reporters.WordReport(bucketer=bucketer, matches=matches,
                                   acc_type=acc_type, header="Word Accuracy Analysis", 
-                                  caption=caption)
+                                  title=title)
   reporter.generate_report(output_fig_file=f'word-acc',
                            output_fig_format='pdf', 
                            output_directory='outputs')
@@ -118,7 +118,7 @@ def generate_src_word_accuracy_report(ref, outs, src, ref_align_file=None, out_a
                           freq_count_file=None, freq_corpus_file=None,
                           label_set=None,
                           src_labels=None,
-                          caption=None,
+                          title=None,
                           case_insensitive=False):
   """
   Generate a report for source word analysis in both plain text and graphs.
@@ -138,7 +138,7 @@ def generate_src_word_accuracy_report(ref, outs, src, ref_align_file=None, out_a
                       he training corpus.
     freq_count_file: An alternative to freq_corpus that uses a count file in "word\tfreq" format.
     src_labels: either a filename of a file full of source labels, or a list of strings corresponding to `ref`.
-    caption: A string specifying the caption of the printed table
+    title: A string specifying the caption of the printed table
     case_insensitive: A boolean specifying whether to turn on the case insensitive option
   """
   case_insensitive = True if case_insensitive == 'True' else False
@@ -164,7 +164,7 @@ def generate_src_word_accuracy_report(ref, outs, src, ref_align_file=None, out_a
 
   reporter = reporters.WordReport(bucketer=bucketer, matches=matches,
                                   acc_type=acc_type, header="Source Word Accuracy Analysis", 
-                                  caption=caption)
+                                  title=title)
   reporter.generate_report(output_fig_file=f'src-word-acc',
                            output_fig_format='pdf', 
                            output_directory='outputs')
@@ -174,7 +174,7 @@ def generate_sentence_bucketed_report(ref, outs,
                                    bucket_type='score', bucket_cutoffs=None,
                                    statistic_type='count',
                                    score_measure='bleu',
-                                   caption=None,
+                                   title=None,
                                    case_insensitive=False):
   """
   Generate a report of sentences by bucket in both plain text and graphs
@@ -184,7 +184,7 @@ def generate_sentence_bucketed_report(ref, outs,
     outs: Tokens from the output file(s)
     bucket_type: The type of bucketing method to use
     score_measure: If using 'score' as either bucket_type or statistic_type, which scorer to use
-    caption: A string specifying the caption of the printed table
+    title: A string specifying the caption of the printed table
     case_insensitive: A boolean specifying whether to turn on the case insensitive option
   """
   case_insensitive = True if case_insensitive == 'True' else False
@@ -207,7 +207,7 @@ def generate_sentence_bucketed_report(ref, outs,
   reporter = reporters.SentenceReport(bucketer=bucketer,
                                       sys_stats=stats,
                                       statistic_type=statistic_type, scorer=scorer, 
-                                      caption=caption)
+                                      title=title)
 
   reporter.generate_report(output_fig_file=f'sentence-{statistic_type}-{score_measure}',
                            output_fig_format='pdf', 
@@ -220,7 +220,7 @@ def generate_ngram_report(ref, outs,
                        report_length=50, alpha=1.0, compare_type='match',
                        ref_labels=None, out_labels=None,
                        compare_directions='0-1',
-                       caption=None,
+                       title=None,
                        case_insensitive=False):
   """
   Generate a report comparing aggregate n-gram statistics in both plain text and graphs
@@ -239,7 +239,7 @@ def generate_ngram_report(ref, outs,
                 If specified, will aggregate statistics over labels instead of n-grams.
     out_labels: output labels. must be specified if ref_labels is specified.
     compare_directions: A string specifying which systems to compare
-    caption: A string specifying the caption of the printed table
+    title: A string specifying the caption of the printed table
     case_insensitive: A boolean specifying whether to turn on the case insensitive option
   """
   min_ngram_length, max_ngram_length, report_length = int(min_ngram_length), int(max_ngram_length), int(report_length)
@@ -290,7 +290,7 @@ def generate_ngram_report(ref, outs,
                                    compare_type=compare_type, alpha=alpha,
                                    compare_directions=direcs,
                                    label_files=label_files,
-                                   caption=caption)                                   
+                                   title=title)                                   
   reporter.generate_report(output_fig_file=f'ngram-min{min_ngram_length}-max{max_ngram_length}-{compare_type}',
                            output_fig_format='pdf', 
                            output_directory='outputs')
@@ -300,7 +300,7 @@ def generate_sentence_examples(ref, outs, src=None,
                             score_type='sentbleu',
                             report_length=10,
                             compare_directions='0-1',
-                            caption=None,
+                            title=None,
                             case_insensitive=False):
   """
   Generate examples of sentences that satisfy some criterion, usually score of one system better
@@ -312,7 +312,7 @@ def generate_sentence_examples(ref, outs, src=None,
     score_type: The type of scorer to use
     report_length: Number of sentences to print for each system being better or worse
     compare_directions: A string specifying which systems to compare
-    caption: A string specifying the caption of the printed table
+    title: A string specifying the caption of the printed table
     case_insensitive: A boolean specifying whether to turn on the case insensitive option
   """
   report_length = int(report_length)
@@ -340,7 +340,7 @@ def generate_sentence_examples(ref, outs, src=None,
                                              scorer=scorer,
                                              ref=ref, outs=outs, src=src,
                                              compare_directions=direcs,
-                                             caption=caption)
+                                             title=title)
   reporter.generate_report()
   return reporter 
 

--- a/compare_mt/compare_mt_main.py
+++ b/compare_mt/compare_mt_main.py
@@ -17,6 +17,7 @@ def generate_score_report(ref, outs,
                        score_type='bleu',
                        bootstrap=0, prob_thresh=0.05,
                        meteor_directory=None, options=None,
+                       caption=None, 
                        case_insensitive=False):
   """
   Generate a report comparing overall scores of system(s) in both plain text and graphs.
@@ -26,7 +27,11 @@ def generate_score_report(ref, outs,
     outs: Tokens from the output file(s)
     score_type: A string specifying the scoring type (bleu/length)
     bootstrap: Number of samples for significance test (0 to disable)
-    compare_directions: A string specifying which systems to compare
+    prob_thresh: P-value threshold for significance test
+    meteor_directory: Path to the directory of the METEOR code
+    options: Options when using external program
+    compare_directions: A string specifying which systems to compare 
+    caption: A string specifying the caption of the printed table
     case_insensitive: A boolean specifying whether to turn on the case insensitive option
   """
   bootstrap = int(bootstrap)
@@ -48,7 +53,8 @@ def generate_score_report(ref, outs,
     wins = sys_stats = direcs = None
 
   reporter = reporters.ScoreReport(scorer=scorer, scores=scores, strs=strs, 
-                                   wins=wins, sys_stats=sys_stats, prob_thresh=prob_thresh)
+                                   wins=wins, sys_stats=sys_stats, prob_thresh=prob_thresh, 
+                                   caption=caption)
   reporter.generate_report(output_fig_file=f'score-{score_type}-{bootstrap}',
                            output_fig_format='pdf', 
                            output_directory='outputs')
@@ -59,6 +65,7 @@ def generate_word_accuracy_report(ref, outs,
                           freq_count_file=None, freq_corpus_file=None,
                           label_set=None,
                           ref_labels=None, out_labels=None,
+                          caption=None,
                           case_insensitive=False):
   """
   Generate a report comparing the word accuracy in both plain text and graphs.
@@ -76,6 +83,7 @@ def generate_word_accuracy_report(ref, outs,
     freq_count_file: An alternative to freq_corpus that uses a count file in "word\tfreq" format.
     ref_labels: either a filename of a file full of reference labels, or a list of strings corresponding to `ref`.
     out_labels: output labels. must be specified if ref_labels is specified.
+    caption: A string specifying the caption of the printed table
     case_insensitive: A boolean specifying whether to turn on the case insensitive option
   """
   case_insensitive = True if case_insensitive == 'True' else False
@@ -97,7 +105,8 @@ def generate_word_accuracy_report(ref, outs,
   matches = [bucketer.calc_bucketed_matches(ref, out, ref_labels=ref_labels, out_labels=out_label) for out, out_label in zip(outs, out_labels)]
   
   reporter = reporters.WordReport(bucketer=bucketer, matches=matches,
-                                  acc_type=acc_type, header="Word Accuracy Analysis")
+                                  acc_type=acc_type, header="Word Accuracy Analysis", 
+                                  caption=caption)
   reporter.generate_report(output_fig_file=f'word-acc',
                            output_fig_format='pdf', 
                            output_directory='outputs')
@@ -109,6 +118,7 @@ def generate_src_word_accuracy_report(ref, outs, src, ref_align_file=None, out_a
                           freq_count_file=None, freq_corpus_file=None,
                           label_set=None,
                           src_labels=None,
+                          caption=None,
                           case_insensitive=False):
   """
   Generate a report for source word analysis in both plain text and graphs.
@@ -128,6 +138,7 @@ def generate_src_word_accuracy_report(ref, outs, src, ref_align_file=None, out_a
                       he training corpus.
     freq_count_file: An alternative to freq_corpus that uses a count file in "word\tfreq" format.
     src_labels: either a filename of a file full of source labels, or a list of strings corresponding to `ref`.
+    caption: A string specifying the caption of the printed table
     case_insensitive: A boolean specifying whether to turn on the case insensitive option
   """
   case_insensitive = True if case_insensitive == 'True' else False
@@ -152,7 +163,8 @@ def generate_src_word_accuracy_report(ref, outs, src, ref_align_file=None, out_a
   matches = [bucketer.calc_source_bucketed_matches(src, ref, out, ref_align, out_align, src_labels=src_labels) for out, out_align in zip(outs, out_aligns)]
 
   reporter = reporters.WordReport(bucketer=bucketer, matches=matches,
-                                  acc_type=acc_type, header="Source Word Accuracy Analysis")
+                                  acc_type=acc_type, header="Source Word Accuracy Analysis", 
+                                  caption=caption)
   reporter.generate_report(output_fig_file=f'src-word-acc',
                            output_fig_format='pdf', 
                            output_directory='outputs')
@@ -162,6 +174,7 @@ def generate_sentence_bucketed_report(ref, outs,
                                    bucket_type='score', bucket_cutoffs=None,
                                    statistic_type='count',
                                    score_measure='bleu',
+                                   caption=None,
                                    case_insensitive=False):
   """
   Generate a report of sentences by bucket in both plain text and graphs
@@ -171,6 +184,7 @@ def generate_sentence_bucketed_report(ref, outs,
     outs: Tokens from the output file(s)
     bucket_type: The type of bucketing method to use
     score_measure: If using 'score' as either bucket_type or statistic_type, which scorer to use
+    caption: A string specifying the caption of the printed table
     case_insensitive: A boolean specifying whether to turn on the case insensitive option
   """
   case_insensitive = True if case_insensitive == 'True' else False
@@ -192,7 +206,8 @@ def generate_sentence_bucketed_report(ref, outs,
 
   reporter = reporters.SentenceReport(bucketer=bucketer,
                                       sys_stats=stats,
-                                      statistic_type=statistic_type, scorer=scorer)
+                                      statistic_type=statistic_type, scorer=scorer, 
+                                      caption=caption)
 
   reporter.generate_report(output_fig_file=f'sentence-{statistic_type}-{score_measure}',
                            output_fig_format='pdf', 
@@ -205,6 +220,7 @@ def generate_ngram_report(ref, outs,
                        report_length=50, alpha=1.0, compare_type='match',
                        ref_labels=None, out_labels=None,
                        compare_directions='0-1',
+                       caption=None,
                        case_insensitive=False):
   """
   Generate a report comparing aggregate n-gram statistics in both plain text and graphs
@@ -223,6 +239,7 @@ def generate_ngram_report(ref, outs,
                 If specified, will aggregate statistics over labels instead of n-grams.
     out_labels: output labels. must be specified if ref_labels is specified.
     compare_directions: A string specifying which systems to compare
+    caption: A string specifying the caption of the printed table
     case_insensitive: A boolean specifying whether to turn on the case insensitive option
   """
   min_ngram_length, max_ngram_length, report_length = int(min_ngram_length), int(max_ngram_length), int(report_length)
@@ -272,7 +289,8 @@ def generate_ngram_report(ref, outs,
                                    matches=matches,
                                    compare_type=compare_type, alpha=alpha,
                                    compare_directions=direcs,
-                                   label_files=label_files)                                   
+                                   label_files=label_files,
+                                   caption=caption)                                   
   reporter.generate_report(output_fig_file=f'ngram-min{min_ngram_length}-max{max_ngram_length}-{compare_type}',
                            output_fig_format='pdf', 
                            output_directory='outputs')
@@ -282,6 +300,7 @@ def generate_sentence_examples(ref, outs, src=None,
                             score_type='sentbleu',
                             report_length=10,
                             compare_directions='0-1',
+                            caption=None,
                             case_insensitive=False):
   """
   Generate examples of sentences that satisfy some criterion, usually score of one system better
@@ -293,6 +312,7 @@ def generate_sentence_examples(ref, outs, src=None,
     score_type: The type of scorer to use
     report_length: Number of sentences to print for each system being better or worse
     compare_directions: A string specifying which systems to compare
+    caption: A string specifying the caption of the printed table
     case_insensitive: A boolean specifying whether to turn on the case insensitive option
   """
   report_length = int(report_length)
@@ -319,7 +339,8 @@ def generate_sentence_examples(ref, outs, src=None,
   reporter = reporters.SentenceExampleReport(report_length=report_length, scorediff_lists=scorediff_lists,
                                              scorer=scorer,
                                              ref=ref, outs=outs, src=src,
-                                             compare_directions=direcs)
+                                             compare_directions=direcs,
+                                             caption=caption)
   reporter.generate_report()
   return reporter 
 
@@ -380,6 +401,10 @@ def main():
                       A path to a directory where a graphical report will be saved. Open index.html in the directory
                       to read the report.
                       """)
+  parser.add_argument('--report_title', type=str, default='compare-mt Analysis Report',
+                      help="""
+                      The name of the HTML report.
+                      """)
   parser.add_argument('--decimals', type=int, default=4,
                       help="Number of decimals to print for floating point numbers")
   args = parser.parse_args()
@@ -394,7 +419,7 @@ def main():
   reporters.sys_names = args.sys_names if args.sys_names else [f'sys{i+1}' for i in range(len(outs))]
   reporters.fig_size = tuple([float(x) for x in args.fig_size.split('x')])
   if len(reporters.sys_names) != len(outs):
-    raise ValueError(f'len(reporters.sys_names) != len(outs) -- {len(reporters.sys_names)} != {len(outs)}')
+    raise ValueError(f'len(sys_names) != len(outs) -- {len(reporters.sys_names)} != {len(outs)}')
 
   reports = []
 
@@ -418,7 +443,7 @@ def main():
 
   # Write all reports into a single html file
   if args.output_directory != None:
-    reporters.generate_html_report(reports, args.output_directory)
+    reporters.generate_html_report(reports, args.output_directory, args.report_title)
 
 if __name__ == '__main__':
   main()

--- a/compare_mt/reporters.py
+++ b/compare_mt/reporters.py
@@ -226,7 +226,7 @@ class WordReport(Report):
     self.header = header
     self.acc_type_map = {'prec': 3, 'rec': 4, 'fmeas': 5}
     self.output_fig_file = f'{next_fig_id()}-wordacc-{bucketer.name()}'
-    self.caption = caption
+    self.caption = caption if caption else f'word {acc_type} by {bucketer.name()} bucket'
 
   def print(self):
     acc_type_map = self.acc_type_map
@@ -237,10 +237,7 @@ class WordReport(Report):
       if at not in acc_type_map:
         raise ValueError(f'Unknown accuracy type {at}')
       aid = acc_type_map[at]
-      if self.caption:
-        print(self.caption)
-      else:
-        print(f'--- word {acc_type} by {bucketer.name()} bucket')
+      print(f'--- {self.caption}')
       for i, bucket_str in enumerate(bucketer.bucket_strs):
         print(f'{bucket_str}', end='')
         for match in matches:
@@ -305,7 +302,7 @@ class NgramReport(Report):
     report_length = self.report_length
     self.print_header('N-gram Difference Analysis')
     if self.caption:
-      print(self.caption)
+      print(f'--- {self.caption}')
     else:
       print(f'--- min_ngram_length={self.min_ngram_length}, max_ngram_length={self.max_ngram_length}')
       print(f'    report_length={report_length}, alpha={self.alpha}, compare_type={self.compare_type}')

--- a/compare_mt/reporters.py
+++ b/compare_mt/reporters.py
@@ -314,6 +314,7 @@ class NgramReport(Report):
       print(f'--- {report_length} n-grams where {sys_names[left]}>{sys_names[right]} in {self.compare_type}')
       for k, v in self.scorelist[i][:report_length]:
         print(f"{' '.join(k)}\t{fmt(v)} (sys{left+1}={self.matches[left][k]}, sys{right+1}={self.matches[right][k]})")
+      print()
       print(f'--- {report_length} n-grams where {sys_names[right]}>{sys_names[left]} in {self.compare_type}')
       for k, v in reversed(self.scorelist[i][-report_length:]):
         print(f"{' '.join(k)}\t{fmt(v)} (sys{left+1}={self.matches[left][k]}, sys{right+1}={self.matches[right][k]})")
@@ -407,6 +408,7 @@ class SentenceExampleReport(Report):
     self.caption = caption
 
   def print(self):
+    self.print_header('Sentence Examples Analysis')
     report_length = self.report_length
     for cnt, (left, right) in enumerate(self.compare_directions):
       ref, out1, out2 = self.ref, self.outs[left], self.outs[right]


### PR DESCRIPTION
Example Usage:

`compare-mt example/ted.ref.eng example/ted.sys1.eng example/ted.sys2.eng --compare_word_accuracies 'bucket_type=freq,caption=mycaption' --report_title 'mytitle' --output_directory outputs`

#85 .