### PR TITLE
Fix sentence bucketer for length difference

### DIFF
--- a/compare_mt/bucketers.py
+++ b/compare_mt/bucketers.py
@@ -430,10 +430,10 @@ class LengthDiffSentenceBucketer(SentenceBucketer):
     self.set_bucket_cutoffs(bucket_cutoffs, num_type='int')
 
   def calc_bucket(self, val, ref=None, label=None):
-    return self.cutoff_into_bucket(len(ref) - len(val))
+    return self.cutoff_into_bucket(len(val) - len(ref))
 
   def name(self):
-    return "reference-output length difference"
+    return "len(output)-len(reference)"
 
   def idstr(self):
     return "lengthdiff"


### PR DESCRIPTION
The sentence bucketer for length difference was doing `len(ref) - len(output)` so positive numbers were ones where it was too short, and negative numbers were ones where it was too long. This isn't very intuitive, so I fixed it to `len(output) - len(ref)` and also made the corresponding axis label more explicit.