### PR TITLE
Account for non-ASCII characters

### DIFF
--- a/compare_mt/corpus_utils.py
+++ b/compare_mt/corpus_utils.py
@@ -1,11 +1,11 @@
 
 def iterate_tokens(filename):
-  with open(filename, "r") as f:
+  with open(filename, "r", encoding="utf-8") as f:
     for line in f:
       yield line.strip().split()
 
 def iterate_nums(filename):
-  with open(filename, "r") as f:
+  with open(filename, "r", encoding="utf-8") as f:
     for line in f:
       yield [float(i) for i in line.strip().split()]
 


### PR DESCRIPTION
From previous Github issue (#70), it seems there is support for non-ASCII texts. However, compare-mt was breaking for me when reading Hindi text. Adding a utf-8 encoding works. 

Probably, a good addition can be to provide an option to the user for selecting the encoding they want?