### PR TITLE
Made tokenization on ascii spaces only

### DIFF
--- a/compare_mt/corpus_utils.py
+++ b/compare_mt/corpus_utils.py
@@ -1,7 +1,7 @@
 def iterate_tokens(filename):
   with open(filename, "r", encoding="utf-8") as f:
     for line in f:
-      yield line.strip().split()
+      yield line.strip().split(' ')
 
 def load_tokens(filename):
   return list(iterate_tokens(filename))
@@ -9,7 +9,7 @@ def load_tokens(filename):
 def iterate_nums(filename):
   with open(filename, "r", encoding="utf-8") as f:
     for line in f:
-      yield [float(i) for i in line.strip().split()]
+      yield [float(i) for i in line.strip().split(' ')]
 
 def load_nums(filename):
   return list(iterate_nums(filename))
@@ -18,7 +18,7 @@ def iterate_alignments(filename):
   with open(filename, "r", encoding="utf-8") as f:
     for line in f:
       try:
-        yield [(int(src),int(trg)) for (src,trg) in [x.split('-') for x in line.strip().split()]]
+        yield [(int(src),int(trg)) for (src,trg) in [x.split('-') for x in line.strip().split(' ')]]
       except:
         raise ValueError(f'Poorly formed alignment line in {filename}:\n{line}')
 


### PR DESCRIPTION
By default, the Python `split()` function also splits on other varieties of whitespace than ascii spaces. However, most other utilities (e.g. word aligners) only consider ascii spaces true word boundaries, so splitting on other varieties of white space could cause incompatibility with these tools. This PR fixes this.