### PR TITLE
Create examples of word buckets

### DIFF
--- a/compare_mt/bucketers.py
+++ b/compare_mt/bucketers.py
@@ -412,13 +412,9 @@ class NumericalLabelWordBucketer(WordBucketer):
       bucket_cutoffs = [0.25, 0.5, 0.75]
     self.set_bucket_cutoffs(bucket_cutoffs)
 
-  def calc_bucket(self, word, ref_label=None, out_label=None, src_label=None):
-    if ref_label:
-      return self.cutoff_into_bucket(float(ref_label))
-    elif out_label:
-      return self.cutoff_into_bucket(float(out_label))
-    elif src_label:
-      return self.cutoff_into_bucket(float(src_label))
+  def calc_bucket(self, word, label=None):
+    if label:
+      return self.cutoff_into_bucket(float(label))
     else:
       raise ValueError('When calculating buckets by label, ref_label or out_label must be non-zero')
 

--- a/compare_mt/bucketers.py
+++ b/compare_mt/bucketers.py
@@ -257,7 +257,7 @@ class WordBucketer(Bucketer):
       for word, ll in zip(sent, list_of_likelihoods):
         if self.case_insensitive:
           word = corpus_utils.lower(word)
-        bucket = self.calc_bucket(word, ref_label=word)
+        bucket = self.calc_bucket(word, label=word)
         bucketed_likelihoods[bucket][0] += ll
         bucketed_likelihoods[bucket][1] += 1
 
@@ -416,7 +416,7 @@ class NumericalLabelWordBucketer(WordBucketer):
     if label:
       return self.cutoff_into_bucket(float(label))
     else:
-      raise ValueError('When calculating buckets by label, ref_label or out_label must be non-zero')
+      raise ValueError('When calculating buckets by label must be non-zero')
 
   def name(self):
     return "numerical labels"

--- a/compare_mt/bucketers.py
+++ b/compare_mt/bucketers.py
@@ -137,12 +137,12 @@ class WordBucketer(Bucketer):
       out_matches += my_out_matches
 
       # Scoring of examples across different dimensions:
-      #  0: overall percentage of matches
-      example_scores[rsi,0] = my_out_matches.sum(axis=0) / (my_ref_total*num_outs+1e-10)
-      #  1: overall percentage of misses
-      example_scores[rsi,1] = (my_ref_total*num_outs-my_out_matches.sum(axis=0)) / (my_ref_total*num_outs+1e-10)
-      #  2: overall variance of matches
-      example_scores[rsi,2] = (my_out_matches / (my_ref_total+1e-10).reshape( (1, num_buckets) )).std(axis=0)
+      #  0: overall variance of matches
+      example_scores[rsi,0] = (my_out_matches / (my_ref_total+1e-10).reshape( (1, num_buckets) )).std(axis=0)
+      #  1: overall percentage of matches
+      example_scores[rsi,1] = my_out_matches.sum(axis=0) / (my_ref_total*num_outs+1e-10)
+      #  2: overall percentage of misses
+      example_scores[rsi,2] = (my_ref_total*num_outs-my_out_matches.sum(axis=0)) / (my_ref_total*num_outs+1e-10)
 
     # Calculate statistics
     statistics = [[] for _ in range(num_outs)]
@@ -158,7 +158,9 @@ class WordBucketer(Bucketer):
         ostatistics.append( (mcnt, rcnt, ocnt, rec, prec, fmeas) )
 
     # Find top-5 examples of each class
-    examples = [[('Good Examples', []), ('Bad Examples', []), ('Divergent Examples', [])] for _ in range(num_buckets)]
+    examples = [[('Examples where some systems were good, some were bad', []),
+                 ('Examples where all systems were good', []),
+                 ('Examples where all systems were bad', [])] for _ in range(num_buckets)]
     # NOTE: This could be made faster with argpartition, but the complexity is probably not worth it
     topn = np.argsort(-example_scores, axis=0)
     for bi, bexamples in enumerate(examples):

--- a/compare_mt/bucketers.py
+++ b/compare_mt/bucketers.py
@@ -96,8 +96,8 @@ class WordBucketer(Bucketer):
       my_out_totals = np.zeros( (num_outs, num_buckets) ,dtype=int)
       my_out_matches = np.zeros( (num_outs, num_buckets) ,dtype=int)
       for oai, (out_all_sent, out_all_label) in enumerate(itertools.zip_longest(outs, out_labels if out_labels else [])):
-        out_sent = out_all_sent[ri]
-        out_label = out_all_label[ri] if out_all_label else []
+        out_sent = out_all_sent[rsi]
+        out_label = out_all_label[rsi] if out_all_label else []
         out_word_cnts = {}
         for oi, (out_word, out_lab) in enumerate(itertools.zip_longest(out_sent, out_label)):
           if self.case_insensitive:

--- a/compare_mt/bucketers.py
+++ b/compare_mt/bucketers.py
@@ -1,4 +1,5 @@
 import itertools
+import numpy as np
 from collections import defaultdict
 
 from compare_mt import corpus_utils
@@ -27,82 +28,112 @@ class Bucketer:
 
 class WordBucketer(Bucketer):
 
-  def calc_bucket(self, val, ref_label=None, out_label=None, src_label=None):
+  def calc_bucket(self, val, label=None):
     """
     Calculate the bucket for a particular word
 
     Args:
       val: The word to calculate the bucket for
-      ref_label: If there's a label on the reference word, add it
-      out_label: If there's a label on the output word, add it
-      src_label: If there's a label on the source word, add it
+      label: If there's a label on the target word, add it
 
     Returns:
       An integer ID of the bucket
     """
     raise NotImplementedError('calc_bucket must be implemented in subclasses of WordBucketer')
 
-  def calc_bucketed_matches(self, ref, out, ref_labels=None, out_labels=None):
+  def calc_statistics_and_examples(self, ref, outs, ref_labels=None, out_labels=None):
     """
-    Calculate the number of matches, bucketed by the type of word we have
+    Calculate match statistics, bucketed by the type of word we have, and IDs of example sentences to show.
     This must be used with a subclass that has self.bucket_strs defined, and self.calc_bucket(word) implemented.
 
     Args:
       ref: The reference corpus
-      out: The output corpus
+      outs: A list of output corpora
       ref_labels: Labels of the reference corpus (optional)
-      out_labels: Labels of the output corpus (should be specified iff ref_labels is)
+      out_labels: Labels of the output corpora (should be specified iff ref_labels is)
 
     Returns:
-      A tuple containing:
+      statistics: containing a list of equal length to out, containing for each system
         both_tot: the frequency of a particular bucket appearing in both output and reference
         ref_tot: the frequency of a particular bucket appearing in just reference
         out_tot: the frequency of a particular bucket appearing in just output
         rec: recall of the bucket
         prec: precision of the bucket
         fmeas: f1-measure of the bucket
+      example_ids: containing a list of equal length to self.bucket_strs. each element is a list of tuples containing
+        title: the title of the type of example (e.g. "Good Examples", "Bad Examples", "Divergent Examples")
+        ids: of each sentence that should be included in the example
     """
     if not hasattr(self, 'case_insensitive'):
       self.case_insensitive = False
-      
-    ref_labels = ref_labels if ref_labels else []
-    out_labels = out_labels if out_labels else []
-    matches = [[0, 0, 0] for x in self.bucket_strs]
-    for ref_sent, out_sent, ref_lab, out_lab in itertools.zip_longest(ref, out, ref_labels, out_labels):
+
+    # Dimensions
+    num_buckets = len(self.bucket_strs)
+    num_outs = len(outs)
+    num_sents = len(ref)
+
+    # Initialize the sufficient statistics for prec/rec/fmeas
+    ref_total = np.zeros(num_buckets, dtype=int)
+    out_totals = np.zeros( (num_outs, num_buckets) ,dtype=int)
+    out_matches = np.zeros( ( num_outs, num_buckets) ,dtype=int)
+    # example_scores = np.zeros(num_sents, num_buckets, 3)
+
+    # Step through the sentences
+    for rsi, (ref_sent, ref_label) in enumerate(itertools.zip_longest(ref, ref_labels if ref_labels else [])):
+      # Process the reference, getting the bucket
       ref_pos = defaultdict(lambda: [])
-      for i, word in enumerate(ref_sent):
+      ref_buckets = np.zeros(len(ref_sent), dtype=int)
+      my_ref_total = np.zeros(num_buckets ,dtype=int)
+      for ri, (ref_word, ref_lab) in enumerate(itertools.zip_longest(ref_sent, ref_label if ref_label else [])):
         if self.case_insensitive:
-          word = corpus_utils.lower(word)
-        ref_pos[word].append(i)
-      for i, word in enumerate(out_sent):
-        if self.case_insensitive:
-          word = corpus_utils.lower(word)
-        if len(ref_pos[word]) > 0:
-          ri = ref_pos[word][0]
-          ref_pos[word] = ref_pos[word][1:]
-          bucket = self.calc_bucket(word,
-                                    ref_label=ref_lab[ri] if ref_lab else None,
-                                    out_label=out_lab[i] if out_lab else None)
-          matches[bucket][0] += 1
-          matches[bucket][1] += 1
+          ref_word = corpus_utils.lower(ref_word)
+        ref_pos[ref_word].append(ri)
+        ref_bucket = self.calc_bucket(ref_word, label=ref_lab)
+        ref_buckets[ri] = ref_bucket
+        my_ref_total[ref_bucket] += 1
+      ref_total += my_ref_total
+      # Process each of the outputs, finding matches
+      my_out_totals = np.zeros( (num_outs, num_buckets) ,dtype=int)
+      my_out_matches = np.zeros( (num_outs, num_buckets) ,dtype=int)
+      for oai, (out_all_sent, out_all_label) in enumerate(itertools.zip_longest(outs, out_labels if out_labels else [])):
+        out_sent = out_all_sent[ri]
+        out_label = out_all_label[ri] if out_all_label else []
+        out_word_cnts = {}
+        for oi, (out_word, out_lab) in enumerate(itertools.zip_longest(out_sent, out_label)):
+          if self.case_insensitive:
+            out_word = corpus_utils.lower(out_word)
+          # If non-existent, or matched too many buckets then skip
+          bucket = None
+          ref_poss = ref_pos.get(out_word, None)
+          if ref_poss:
+            out_word_cnt = out_word_cnts.get(out_word, 0)
+            if out_word_cnt < len(ref_poss):
+              bucket = ref_buckets[ref_poss[out_word_cnt]]
+              my_out_matches[oai,bucket] += 1
+            out_word_cnts[out_word] = out_word_cnt + 1
+          if not bucket:
+            bucket = self.calc_bucket(out_word, label=out_lab)
+          my_out_totals[oai,bucket] += 1
+      out_totals += my_out_totals
+      out_matches += my_out_matches
+
+      # TODO: Scoring of example IDs across different dimensions:
+      #  0: overall percentage of matches
+      #  1: overall percentage of misses
+      #  2: overall variance of matches
+
+    ret = [[] for _ in range(num_outs)]
+    for oi, oret in enumerate(ret):
+      for bi in range(num_buckets):
+        mcnt, ocnt, rcnt = out_matches[oi,bi], out_totals[oi,bi], ref_total[bi]
+        if mcnt == 0:
+          rec, prec, fmeas = 0.0, 0.0, 0.0
         else:
-          bucket = self.calc_bucket(word,
-                                    out_label=out_lab[i] if out_lab else None)
-        matches[bucket][2] += 1
-      for word, my_pos in ref_pos.items():
-        if len(my_pos) > 0:
-          for ri in my_pos:
-            bucket = self.calc_bucket(ref_sent[ri],
-                                      ref_label=ref_lab[ri] if ref_lab else None)
-            matches[bucket][1] += 1
-    for both_tot, ref_tot, out_tot in matches:
-      if both_tot == 0:
-        rec, prec, fmeas = 0.0, 0.0, 0.0
-      else:
-        rec = both_tot / float(ref_tot)
-        prec = both_tot / float(out_tot)
-        fmeas = 2 * prec * rec / (prec + rec)
-      yield both_tot, ref_tot, out_tot, rec, prec, fmeas
+          rec = mcnt / float(rcnt)
+          prec = mcnt / float(ocnt)
+          fmeas = 2 * prec * rec / (prec + rec)
+        oret.append( (mcnt, rcnt, ocnt, rec, prec, fmeas) )
+    return ret, None
 
   def calc_source_bucketed_matches(self, src, ref, out, ref_aligns, out_aligns, src_labels=None):
     """
@@ -143,7 +174,7 @@ class WordBucketer(Bucketer):
         if self.case_insensitive:
           word = corpus_utils.lower(word)
         bucket = self.calc_bucket(src_word,
-                                  src_label=src_lab[src_index] if src_lab else None)
+                                  label=src_lab[src_index] if src_lab else None)
         if ref_cnt[word] > 0:
           ref_cnt[word] -= 1
           matches[bucket][0] += 1
@@ -151,7 +182,7 @@ class WordBucketer(Bucketer):
       for i, (src_index, trg_index) in enumerate(ref_align):
         src_word = src_sent[src_index]
         bucket = self.calc_bucket(src_word,
-                                  src_label=src_lab[src_index] if src_lab else None)
+                                  label=src_lab[src_index] if src_lab else None)
         matches[bucket][1] += 1
 
     for both_tot, ref_tot, out_tot in matches:
@@ -262,7 +293,7 @@ class FreqWordBucketer(WordBucketer):
       bucket_cutoffs = [1, 2, 3, 4, 5, 10, 100, 1000]
     self.set_bucket_cutoffs(bucket_cutoffs)
 
-  def calc_bucket(self, word, ref_label=None, out_label=None, src_label=None):
+  def calc_bucket(self, word, label=None):
     if self.case_insensitive:
       return self.cutoff_into_bucket(self.freq_counts.get(corpus_utils.lower(word), 0))
     else:
@@ -283,7 +314,7 @@ class CaseWordBucketer(WordBucketer):
     """
     self.bucket_strs = ['lower', 'upper', 'title', 'other']
 
-  def calc_bucket(self, word, ref_label=None, out_label=None, src_label=None):
+  def calc_bucket(self, word, label=None):
     if word.islower():
       return 0
     elif word.isupper():
@@ -317,15 +348,10 @@ class LabelWordBucketer(WordBucketer):
     for i, l in enumerate(label_set):
       self.bucket_map[l] = i
 
-  def calc_bucket(self, word, ref_label=None, out_label=None, src_label=None):
-    if ref_label:
-      return self.bucket_map[ref_label]
-    elif out_label:
-      return self.bucket_map[out_label]
-    elif src_label:
-      return self.bucket_map[src_label]
-    else:
-      raise ValueError('When calculating buckets by label, ref_label or out_label must be non-zero')
+  def calc_bucket(self, word, label=None):
+    if not label:
+      raise ValueError('When calculating buckets by label, label must be non-zero')
+    return self.bucket_map[label]
 
   def name(self):
     return "labels"

--- a/compare_mt/compare_mt_main.py
+++ b/compare_mt/compare_mt_main.py
@@ -102,9 +102,10 @@ def generate_word_accuracy_report(ref, outs,
                                                          case_insensitive=case_insensitive)
   ref_labels = corpus_utils.load_tokens(ref_labels) if type(ref_labels) == str else ref_labels
   out_labels = [corpus_utils.load_tokens(out_labels[i]) if not out_labels is None else None for i in range(len(outs))]
-  matches = [bucketer.calc_bucketed_matches(ref, out, ref_labels=ref_labels, out_labels=out_label) for out, out_label in zip(outs, out_labels)]
-  
-  reporter = reporters.WordReport(bucketer=bucketer, matches=matches,
+  statistics, example_ids = bucketer.calc_statistics_and_examples(ref, outs, ref_labels=ref_labels, out_labels=out_labels)
+
+  reporter = reporters.WordReport(bucketer=bucketer,
+                                  matches=statistics,
                                   acc_type=acc_type, header="Word Accuracy Analysis", 
                                   title=title)
   reporter.generate_report(output_fig_file=f'word-acc',

--- a/compare_mt/compare_mt_main.py
+++ b/compare_mt/compare_mt_main.py
@@ -101,7 +101,7 @@ def generate_word_accuracy_report(ref, outs,
                                                          label_set=label_set,
                                                          case_insensitive=case_insensitive)
   ref_labels = corpus_utils.load_tokens(ref_labels) if type(ref_labels) == str else ref_labels
-  out_labels = [corpus_utils.load_tokens(out_labels[i]) if not out_labels is None else None for i in range(len(outs))]
+  out_labels = [corpus_utils.load_tokens(out_labels[i])] if (not out_labels is None) else None
   statistics, example_ids = bucketer.calc_statistics_and_examples(ref, outs, ref_labels=ref_labels, out_labels=out_labels)
 
   reporter = reporters.WordReport(bucketer=bucketer,

--- a/compare_mt/compare_mt_main.py
+++ b/compare_mt/compare_mt_main.py
@@ -88,8 +88,10 @@ def generate_word_accuracy_report(ref, outs,
   """
   case_insensitive = True if case_insensitive == 'True' else False
 
+  if type(ref_labels) == str:
+    ref_labels = corpus_utils.load_tokens(ref_labels)
   if out_labels is not None:
-    out_labels = arg_utils.parse_files(out_labels)
+    out_labels = [corpus_utils.load_tokens(x) for x in arg_utils.parse_files(out_labels)]
     if len(out_labels) != len(outs):
       raise ValueError(f'The number of output files should be equal to the number of output labels.')
 
@@ -100,13 +102,16 @@ def generate_word_accuracy_report(ref, outs,
                                                          freq_data=ref,
                                                          label_set=label_set,
                                                          case_insensitive=case_insensitive)
-  ref_labels = corpus_utils.load_tokens(ref_labels) if type(ref_labels) == str else ref_labels
-  out_labels = [corpus_utils.load_tokens(out_labels[i])] if (not out_labels is None) else None
-  statistics, example_ids = bucketer.calc_statistics_and_examples(ref, outs, ref_labels=ref_labels, out_labels=out_labels)
+  statistics, examples = bucketer.calc_statistics_and_examples(ref, outs, ref_labels=ref_labels, out_labels=out_labels)
 
   reporter = reporters.WordReport(bucketer=bucketer,
-                                  matches=statistics,
-                                  acc_type=acc_type, header="Word Accuracy Analysis", 
+                                  statistics=statistics,
+                                  examples=examples,
+                                  ref_sents=ref,
+                                  ref_labels=ref_labels,
+                                  out_sents=outs,
+                                  out_labels=out_labels,
+                                  acc_type=acc_type, header="Word Accuracy Analysis",
                                   title=title)
   reporter.generate_report(output_fig_file=f'word-acc',
                            output_fig_format='pdf', 

--- a/compare_mt/compare_mt_main.py
+++ b/compare_mt/compare_mt_main.py
@@ -166,9 +166,10 @@ def generate_src_word_accuracy_report(ref, outs, src, ref_align_file=None, out_a
                                                          label_set=label_set,
                                                          case_insensitive=case_insensitive)
   src_labels = corpus_utils.load_tokens(src_labels) if type(src_labels) == str else src_labels
-  matches = [bucketer.calc_source_bucketed_matches(src, ref, out, ref_align, out_align, src_labels=src_labels) for out, out_align in zip(outs, out_aligns)]
+  statistics = [bucketer.calc_source_bucketed_matches(src, ref, out, ref_align, out_align, src_labels=src_labels) for out, out_align in zip(outs, out_aligns)]
 
-  reporter = reporters.WordReport(bucketer=bucketer, matches=matches,
+  reporter = reporters.WordReport(bucketer=bucketer,
+                                  statistics=statistics,
                                   acc_type=acc_type, header="Source Word Accuracy Analysis", 
                                   title=title)
   reporter.generate_report(output_fig_file=f'src-word-acc',

--- a/compare_mt/reporters.py
+++ b/compare_mt/reporters.py
@@ -271,8 +271,10 @@ class WordReport(Report):
                      xlabel=self.bucketer.name(), ylabel=at,
                      xticklabels=xticklabels)
 
-  def highlight_buckets(self, sent, buck, bid):
-    return ' '.join([w if b != bid else f'<em>{w}</em>' for (w,b) in zip(sent, buck)])
+  def highlight_buckets(self, sent, buck, bid, matches=None):
+    if not matches:
+      matches = [1 for _ in buck]
+    return ' '.join([w if (b != bid or m < 0) else f'<em>{w}</em>' for (w,b,m) in zip(sent, buck, matches)])
 
   def write_examples(self, title, output_directory):
     # Create separate examples HTML file
@@ -298,8 +300,8 @@ class WordReport(Report):
           # if self.src:
           #   table.append(['Src', ' '.join(self.src[eid])])
           table.append(['Ref', self.highlight_buckets(self.ref_sents[eid], ref_buckets, bi)])
-          for sn, oss, obs in zip(sys_names, self.out_sents, out_buckets):
-            table.append([sn, self.highlight_buckets(oss[eid], obs, bi)])
+          for sn, oss, obs, ms in zip(sys_names, self.out_sents, out_buckets, matches):
+            table.append([sn, self.highlight_buckets(oss[eid], obs, bi, matches=ms)])
           html += html_table(table, None)
     with open(f'{output_directory}/{self.output_fig_file}.html', 'w') as example_stream:
       example_stream.write(styled_html_message(title, html))

--- a/compare_mt/reporters.py
+++ b/compare_mt/reporters.py
@@ -319,7 +319,7 @@ class WordReport(Report):
       if at not in acc_type_map:
         raise ValueError(f'Unknown accuracy type {at}')
       aid = acc_type_map[at]
-      table = [[bucketer.name()] + sys_names]
+      table = [[bucketer.name()] + sys_names + ['Examples']]
       for i, bs in enumerate(bucketer.bucket_strs):
         line = [bs]
         for match in matches:

--- a/compare_mt/reporters.py
+++ b/compare_mt/reporters.py
@@ -222,10 +222,12 @@ class ScoreReport(Report):
     return html
     
 class WordReport(Report):
-  def __init__(self, bucketer, statistics, examples,
-               ref_sents, ref_labels,
-               out_sents, out_labels,
-               acc_type, header, title=None):
+  def __init__(self, bucketer, statistics,
+               acc_type, header,
+               examples=None,
+               ref_sents=None, ref_labels=None,
+               out_sents=None, out_labels=None,
+               title=None):
     self.bucketer = bucketer
     self.statistics = [[s for s in stat] for stat in statistics]
     self.examples = examples
@@ -313,7 +315,8 @@ class WordReport(Report):
 
     title = f'Word {acc_type} by {bucketer.name()} bucket' if not self.title else self.title
 
-    self.write_examples(title, output_directory)
+    if self.examples:
+      self.write_examples(title, output_directory)
 
     # Create main HTML content
     html = ''
@@ -321,12 +324,15 @@ class WordReport(Report):
       if at not in acc_type_map:
         raise ValueError(f'Unknown accuracy type {at}')
       aid = acc_type_map[at]
-      table = [[bucketer.name()] + sys_names + ['Examples']]
+      table = [[bucketer.name()] + sys_names]
+      if self.examples:
+        table[0].append('Examples')
       for i, bs in enumerate(bucketer.bucket_strs):
         line = [bs]
         for match in matches:
           line.append(f'{fmt(match[i][aid])}')
-        line.append(f'<a href="{self.output_fig_file}.html#bucket{i}">Examples</a>')
+        if self.examples:
+          line.append(f'<a href="{self.output_fig_file}.html#bucket{i}">Examples</a>')
         table += [line] 
       html += html_table(table, title)
       img_name = f'{self.output_fig_file}-{at}'


### PR DESCRIPTION
Start of adding https://github.com/neulab/compare-mt/issues/26

This now allows you to click through to examples of individual buckets. Here is what it looks like on the main HTML page:

<img width="325" alt="Screen Shot 2019-06-28 at 11 03 38 PM" src="https://user-images.githubusercontent.com/398875/60378989-fd2c7880-99f8-11e9-8fb0-8b73ded23393.png">

Once you click on a link it will give you a link to some examples where
* some systems are good, some are bad
* all systems are good
* all systems are bad

<img width="1134" alt="Screen Shot 2019-06-28 at 11 13 01 PM" src="https://user-images.githubusercontent.com/398875/60379083-63fe6180-99fa-11e9-85d7-b3cd2e5c701c.png">

<img width="1115" alt="Screen Shot 2019-06-28 at 11 14 28 PM" src="https://user-images.githubusercontent.com/398875/60379091-8a240180-99fa-11e9-9730-c181862e3ec4.png">

<img width="1132" alt="Screen Shot 2019-06-28 at 11 14 43 PM" src="https://user-images.githubusercontent.com/398875/60379093-8db78880-99fa-11e9-97d2-2bd03692d27d.png">
