### PR TITLE
Some measure of bucketed statistic reliability

### DIFF
--- a/compare_mt/__init__.py
+++ b/compare_mt/__init__.py
@@ -9,4 +9,4 @@ import compare_mt.arg_utils
 import compare_mt.print_utils
 
 
-__version__ = "0.2.6"
+__version__ = "0.2.7"

--- a/compare_mt/bucketers.py
+++ b/compare_mt/bucketers.py
@@ -581,10 +581,9 @@ class SentenceBucketer(Bucketer):
       ref_labels = out_labels
     
     for i, (out_words, ref_words) in enumerate(zip(out, ref)):
-      bucket = self.calc_bucket(out_words, ref=(ref_words if ref else None), label=(ref_labels[i][0] if ref_labels else None))
+      bucket = self.calc_bucket(out_words, ref_words, label=(ref_labels[i][0] if ref_labels else None))
       bucketed_corpus[bucket][0].append(out_words)
-      if ref != None:
-        bucketed_corpus[bucket][1].append(ref_words)
+      bucketed_corpus[bucket][1].append(ref_words)
 
     return bucketed_corpus
 
@@ -625,7 +624,7 @@ class LengthSentenceBucketer(SentenceBucketer):
     self.set_bucket_cutoffs(bucket_cutoffs, num_type='int')
 
   def calc_bucket(self, val, ref=None, label=None):
-    return self.cutoff_into_bucket(len(val))
+    return self.cutoff_into_bucket(len(ref))
 
   def name(self):
     return "length"

--- a/compare_mt/compare_mt_main.py
+++ b/compare_mt/compare_mt_main.py
@@ -338,12 +338,14 @@ def generate_sentence_bucketed_report(ref, outs,
     stats = [[aggregator(out,ref) for (out,ref) in bc] for bc in bcs]
 
   if output_bucket_details and statistic_type == 'score':
-    bucket_detail_calculator = lambda out,ref: (len(out), sign_utils.eval_with_paired_bootstrap(ref, [out], scorer, None)[1][0])
+    bucket_cnt_calculator = lambda out,ref: len(out)
+    bucket_interval_calculator = lambda out,ref: sign_utils.eval_with_paired_bootstrap(ref, [out], scorer, None)[1][0]
     if cache_dicts is not None: # we don't cache bcs
       bcs = [bucketer.create_bucketed_corpus(out, ref=ref, ref_labels=ref_labels if ref_labels else None, out_labels=out_labels[i] if out_labels else None) for i, out in enumerate(outs)]
-    bucket_details = [[bucket_detail_calculator(out,ref) for (out,ref) in bc] for bc in bcs]
+    bucket_cnts = [bucket_cnt_calculator(out,ref) for (out,ref) in bcs[0]]
+    bucket_intervals = [[bucket_interval_calculator(out,ref) for (out,ref) in bc] for bc in bcs]
   else:
-    bucket_details = None
+    bucket_cnts = bucket_intervals = None
   
 
   if to_cache:
@@ -354,7 +356,8 @@ def generate_sentence_bucketed_report(ref, outs,
   reporter = reporters.SentenceReport(bucketer=bucketer,
                                       sys_stats=stats,
                                       statistic_type=statistic_type, scorer=scorer, 
-                                      bucket_details=bucket_details,
+                                      bucket_cnts=bucket_cnts,
+                                      bucket_intervals=bucket_intervals,
                                       title=title)
 
   reporter.generate_report(output_fig_file=f'sentence-{statistic_type}-{score_measure}',

--- a/compare_mt/compare_mt_main.py
+++ b/compare_mt/compare_mt_main.py
@@ -320,7 +320,9 @@ def generate_sentence_bucketed_report(ref, outs,
 
   if statistic_type == 'count':
     scorer = None
-    aggregator = lambda out,ref: len(out)
+    if bucket_type != 'score' and bucket_type != 'lengthdiff':
+      ref = ref_label = None
+    aggregator = lambda out,refs: len(out)
   elif statistic_type == 'score':
     scorer = scorers.create_scorer_from_profile(score_measure, case_insensitive=case_insensitive)
     aggregator = lambda out,ref: scorer.score_corpus(ref,out)[0]

--- a/compare_mt/compare_mt_main.py
+++ b/compare_mt/compare_mt_main.py
@@ -87,6 +87,7 @@ def generate_word_accuracy_report(ref, outs,
                           ref_labels=None, out_labels=None,
                           title=None,
                           case_insensitive=False,
+                          output_bucket_details=False,
                           to_cache=False,
                           cache_dicts=None):
   """
@@ -108,12 +109,15 @@ def generate_word_accuracy_report(ref, outs,
     out_labels: output labels. must be specified if ref_labels is specified.
     title: A string specifying the caption of the printed table
     case_insensitive: A boolean specifying whether to turn on the case insensitive option
+    output_bucket_details: A boolean specifying whether to output the number of words in each bucket
     to_cache: Return a list of computed statistics if True
     cache_dicts: A list of dictionaries that store cached statistics for each output
   """
   # check and set parameters
   if type(case_insensitive) == str:
     case_insensitive = True if case_insensitive == 'True' else False
+  if type(output_bucket_details) == str:
+    output_bucket_details = True if output_bucket_details == 'True' else False
 
   if type(ref_labels) == str:
     ref_labels = corpus_utils.load_tokens(ref_labels)
@@ -135,23 +139,28 @@ def generate_word_accuracy_report(ref, outs,
                                                          label_set=label_set,
                                                          case_insensitive=case_insensitive)
 
-  cache_key_list = ['statistics', 'my_ref_total_list', 'my_out_matches_list']
-  statistics, my_ref_total_list, my_out_matches_list = cache_utils.extract_cache_dicts(cache_dicts, cache_key_list, len(outs))
+  cache_key_list = ['statistics', 'my_ref_total_list', 'my_out_totals_list', 'my_out_matches_list']
+  statistics, my_ref_total_list, my_out_totals_list, my_out_matches_list = cache_utils.extract_cache_dicts(cache_dicts, cache_key_list, len(outs))
   if cache_dicts is None:
-    statistics, my_ref_total_list, my_out_matches_list = bucketer.calc_statistics(ref, outs, ref_labels=ref_labels, out_labels=out_labels)
+    statistics, my_ref_total_list, my_out_totals_list, my_out_matches_list = bucketer.calc_statistics(ref, outs, ref_labels=ref_labels, out_labels=out_labels)
   else:
     my_ref_total_list = my_ref_total_list[0]
+    my_out_totals_list = list(np.concatenate(my_out_totals_list, 1))
     my_out_matches_list = list(np.concatenate(my_out_matches_list, 1))
   examples = bucketer.calc_examples(len(ref), len(outs), statistics, my_ref_total_list, my_out_matches_list)
 
+  bucket_cnts, bucket_intervals = bucketer.calc_bucket_details(my_ref_total_list, my_out_totals_list, my_out_matches_list) if output_bucket_details else (None, None)
+
   if to_cache:
-    cache_dict = cache_utils.return_cache_dict(cache_key_list, [statistics, [my_ref_total_list], [my_out_matches_list]])
+    cache_dict = cache_utils.return_cache_dict(cache_key_list, [statistics, [my_ref_total_list], [my_out_totals_list] ,[my_out_matches_list]])
     return cache_dict
 
   # generate reports
   reporter = reporters.WordReport(bucketer=bucketer,
                                   statistics=statistics,
                                   examples=examples,
+                                  bucket_cnts=bucket_cnts,
+                                  bucket_intervals=bucket_intervals,
                                   src_sents=src,
                                   ref_sents=ref,
                                   ref_labels=ref_labels,
@@ -172,6 +181,7 @@ def generate_src_word_accuracy_report(ref, outs, src, ref_align_file=None,
                           src_labels=None,
                           title=None,
                           case_insensitive=False,
+                          output_bucket_details=False,
                           to_cache=False,
                           cache_dicts=None):
   """
@@ -193,12 +203,15 @@ def generate_src_word_accuracy_report(ref, outs, src, ref_align_file=None,
     src_labels: either a filename of a file full of source labels, or a list of strings corresponding to `ref`.
     title: A string specifying the caption of the printed table
     case_insensitive: A boolean specifying whether to turn on the case insensitive option
+    output_bucket_details: A boolean specifying whether to output the number of words in each bucket
     to_cache: Return a list of computed statistics if True
     cache_dicts: A list of dictionaries that store cached statistics for each output
   """
   # check and set parameters
   if type(case_insensitive) == str:
     case_insensitive = True if case_insensitive == 'True' else False
+  if type(output_bucket_details) == str:
+    output_bucket_details = True if output_bucket_details == 'True' else False
 
   if acc_type != 'rec':
     raise ValueError("Source word analysis can only use recall as an accuracy type")
@@ -218,23 +231,28 @@ def generate_src_word_accuracy_report(ref, outs, src, ref_align_file=None,
                                                          label_set=label_set,
                                                          case_insensitive=case_insensitive)
 
-  cache_key_list = ['statistics', 'my_ref_total_list', 'my_out_matches_list']
-  statistics, my_ref_total_list, my_out_matches_list = cache_utils.extract_cache_dicts(cache_dicts, cache_key_list, len(outs))
+  cache_key_list = ['statistics', 'my_ref_total_list', 'my_out_totals_list', 'my_out_matches_list']
+  statistics, my_ref_total_list, my_out_totals_list, my_out_matches_list = cache_utils.extract_cache_dicts(cache_dicts, cache_key_list, len(outs))
   if cache_dicts is not None:
     my_ref_total_list = my_ref_total_list[0]
+    my_out_totals_list = list(np.concatenate(my_out_totals_list, 1))
     my_out_matches_list = list(np.concatenate(my_out_matches_list, 1))
   else:
-    statistics, my_ref_total_list, my_out_matches_list = bucketer.calc_statistics(ref, outs, src=src, src_labels=src_labels, ref_aligns=ref_align)
+    statistics, my_ref_total_list, my_out_totals_list, my_out_matches_list = bucketer.calc_statistics(ref, outs, src=src, src_labels=src_labels, ref_aligns=ref_align)
   examples = bucketer.calc_examples(len(ref), len(outs), statistics, my_ref_total_list, my_out_matches_list)
 
+  bucket_cnts, bucket_intervals = bucketer.calc_bucket_details(my_ref_total_list, my_out_totals_list, my_out_matches_list) if output_bucket_details else (None, None)
+
   if to_cache:
-    cache_dict = cache_utils.return_cache_dict(cache_key_list, [statistics, [my_ref_total_list], [my_out_matches_list]])
+    cache_dict = cache_utils.return_cache_dict(cache_key_list, [statistics, [my_ref_total_list], [my_out_totals_list], [my_out_matches_list]])
     return cache_dict
 
   # generate reports
   reporter = reporters.WordReport(bucketer=bucketer,
                                   statistics=statistics,
                                   examples=examples,
+                                  bucket_cnts=bucket_cnts,
+                                  bucket_intervals=bucket_intervals,
                                   src_sents=src,
                                   ref_sents=ref,
                                   ref_aligns=ref_align,
@@ -256,6 +274,7 @@ def generate_sentence_bucketed_report(ref, outs,
                                    ref_labels=None, out_labels=None,
                                    title=None,
                                    case_insensitive=False,
+                                   output_bucket_details=False,
                                    to_cache=False,
                                    cache_dicts=None):
   """
@@ -270,12 +289,15 @@ def generate_sentence_bucketed_report(ref, outs,
     out_labels: output labels. 
     title: A string specifying the caption of the printed table
     case_insensitive: A boolean specifying whether to turn on the case insensitive option
+    output_bucket_details: A boolean specifying whether to output the number of words in each bucket
     to_cache: Return a list of computed statistics if True
     cache_dicts: A list of dictionaries that store cached statistics for each output
   """
   # check and set parameters
   if type(case_insensitive) == str:
     case_insensitive = True if case_insensitive == 'True' else False
+  if type(output_bucket_details) == str:
+    output_bucket_details = True if output_bucket_details == 'True' else False
 
   if ref_labels is not None:
     ref_labels = corpus_utils.load_tokens(ref_labels) if type(ref_labels) == str else ref_labels
@@ -304,6 +326,7 @@ def generate_sentence_bucketed_report(ref, outs,
     aggregator = lambda out,ref: scorer.score_corpus(ref,out)[0]
   else:
     raise ValueError(f'Illegal statistic_type {statistic_type}')
+  
 
   cache_key_list = ['stats']
   stats = cache_utils.extract_cache_dicts(cache_dicts, cache_key_list, len(outs))
@@ -311,6 +334,15 @@ def generate_sentence_bucketed_report(ref, outs,
   if cache_dicts is None:
     bcs = [bucketer.create_bucketed_corpus(out, ref=ref, ref_labels=ref_labels if ref_labels else None, out_labels=out_labels[i] if out_labels else None) for i, out in enumerate(outs)]
     stats = [[aggregator(out,ref) for (out,ref) in bc] for bc in bcs]
+
+  if output_bucket_details and statistic_type == 'score':
+    bucket_detail_calculator = lambda out,ref: (len(out), sign_utils.eval_with_paired_bootstrap(ref, [out], scorer, None)[1][0])
+    if cache_dicts is not None: # we don't cache bcs
+      bcs = [bucketer.create_bucketed_corpus(out, ref=ref, ref_labels=ref_labels if ref_labels else None, out_labels=out_labels[i] if out_labels else None) for i, out in enumerate(outs)]
+    bucket_details = [[bucket_detail_calculator(out,ref) for (out,ref) in bc] for bc in bcs]
+  else:
+    bucket_details = None
+  
 
   if to_cache:
     cache_dict = cache_utils.return_cache_dict(cache_key_list, [stats])
@@ -320,6 +352,7 @@ def generate_sentence_bucketed_report(ref, outs,
   reporter = reporters.SentenceReport(bucketer=bucketer,
                                       sys_stats=stats,
                                       statistic_type=statistic_type, scorer=scorer, 
+                                      bucket_details=bucket_details,
                                       title=title)
 
   reporter.generate_report(output_fig_file=f'sentence-{statistic_type}-{score_measure}',

--- a/compare_mt/reporters.py
+++ b/compare_mt/reporters.py
@@ -392,7 +392,7 @@ class WordReport(Report):
           line.append(f'{fmt(match[i][aid])}')
           if self.bucket_intervals is not None:
             low, up = self.bucket_intervals[j][i][aid]
-            line[-1] += f'<font size=2> ({fmt(low)}, {fmt(up)})</font>'
+            line[-1] += f'<font size=2> [{fmt(low)}, {fmt(up)}]</font>'
         if self.examples:
           line.append(f'<a href="{self.output_fig_file}.html#bucket{i}">Examples</a>')
         table += [line] 
@@ -545,7 +545,7 @@ class SentenceReport(Report):
         if self.bucket_intervals is not None:
           interval =  self.bucket_intervals[j][i]
           low, up = interval['lower_bound'], interval['upper_bound']
-          line[-1] += f'<font size=2> ({fmt(low)}, {fmt(up)})</font>'
+          line[-1] += f'<font size=2> [{fmt(low)}, {fmt(up)}]</font>'
       table.extend([line])
     html = html_table(table, self.title)
     for ext in ('png', 'pdf'):

--- a/compare_mt/reporters.py
+++ b/compare_mt/reporters.py
@@ -170,7 +170,7 @@ class ScoreReport(Report):
       return [
         [""]+sys_names,
         [self.scorer.name()]+self.strs,
-        [""]+[f'[{x["lower_bound"]:.4f},{x["upper_bound"]:.4f}]' for x in self.sys_stats]
+        [""]+[f'[{fmt(x["lower_bound"])},{fmt(x["upper_bound"])}]' for x in self.sys_stats]
       ], None
     elif len(self.scores) == 2:
       # Single table with scores and wins for two systems
@@ -261,15 +261,23 @@ class WordReport(Report):
         raise ValueError(f'Unknown accuracy type {at}')
       aid = acc_type_map[at]
       print(f'--- {self.title}')
+      # first line
+      print(f'{bucketer.name()}', end='')
+      if self.bucket_cnts is not None:
+        print(f'\t# words', end='')
+      for sn in sys_names:
+        print(f'\t{sn}', end='')
+      print()
+      # stats
       for i, bucket_str in enumerate(bucketer.bucket_strs):
         print(f'{bucket_str}', end='')
         if self.bucket_cnts is not None:
-          print(f' (#words: {self.bucket_cnts[i]})', end='')
+          print(f'\t{self.bucket_cnts[i]}', end='')
         for j, match in enumerate(statistics):
           print(f'\t{fmt(match[i][aid])}', end='')
           if self.bucket_intervals is not None:
             low, up = self.bucket_intervals[j][i][aid]
-            print(f' ({fmt(low)}, {fmt(up)})', end='')
+            print(f' [{fmt(low)}, {fmt(up)}]', end='')
         print()
       print()
 
@@ -282,9 +290,22 @@ class WordReport(Report):
       sys = [[m[aid] for m in match] for match in self.statistics]
       xticklabels = [s for s in self.bucketer.bucket_strs] 
 
+      if self.bucket_intervals:
+        errs = []
+        for i, match in enumerate(sys):
+          lows, ups = [], []
+          for j, score in enumerate(match):
+            low, up = self.bucket_intervals[i][j][aid] 
+            lows.append(score-low)
+            ups.append(up-score)
+          errs.append(np.array([lows, ups]) )
+      else:
+        errs = None
+
       make_bar_chart(sys,
                      output_directory, output_fig_file,
                      output_fig_format=output_fig_format,
+                     errs=errs,
                      xlabel=self.bucketer.name(), ylabel=at,
                      xticklabels=xticklabels)
 
@@ -356,18 +377,22 @@ class WordReport(Report):
       if at not in acc_type_map:
         raise ValueError(f'Unknown accuracy type {at}')
       aid = acc_type_map[at]
-      table = [[bucketer.name()] + sys_names]
+      line = [bucketer.name()]
+      if self.bucket_cnts is not None:
+        line.append('# words')
+      line += sys_names
+      table = [line]
       if self.examples:
         table[0].append('Examples')
       for i, bs in enumerate(bucketer.bucket_strs):
         line = [bs]
         if self.bucket_cnts is not None:
-          line[-1] += f' (#words: {self.bucket_cnts[i]})'
+          line.append(f'{self.bucket_cnts[i]}')
         for j, match in enumerate(matches):
           line.append(f'{fmt(match[i][aid])}')
           if self.bucket_intervals is not None:
             low, up = self.bucket_intervals[j][i][aid]
-            line[-1] += f' ({fmt(low)}, {fmt(up)})'
+            line[-1] += f'<font size=2> ({fmt(low)}, {fmt(up)})</font>'
         if self.examples:
           line.append(f'<a href="{self.output_fig_file}.html#bucket{i}">Examples</a>')
         table += [line] 
@@ -441,12 +466,13 @@ class NgramReport(Report):
 
 class SentenceReport(Report):
 
-  def __init__(self, bucketer=None, sys_stats=None, statistic_type=None, scorer=None, bucket_details=None, title=None):
+  def __init__(self, bucketer=None, sys_stats=None, statistic_type=None, scorer=None, bucket_cnts=None, bucket_intervals=None, title=None):
     self.bucketer = bucketer
     self.sys_stats = [[s for s in stat] for stat in sys_stats]
     self.statistic_type = statistic_type
     self.scorer = scorer
-    self.bucket_details = bucket_details
+    self.bucket_cnts = bucket_cnts
+    self.bucket_intervals = bucket_intervals
     self.yname = scorer.name() if statistic_type == 'score' else statistic_type
     self.yidstr = scorer.idstr() if statistic_type == 'score' else statistic_type
     self.output_fig_file = f'{next_fig_id()}-sent-{bucketer.idstr()}-{self.yidstr}'
@@ -460,15 +486,23 @@ class SentenceReport(Report):
   def print(self):
     self.print_header('Sentence Bucket Analysis')
     print(f'--- {self.title}')
+    # first line
+    print(f'{self.bucketer.idstr()}', end='')
+    if self.bucket_cnts is not None:
+      print(f'\t# sents', end='')
+    for sn in sys_names:
+      print(f'\t{sn}', end='')
+    print()
     for i, bs in enumerate(self.bucketer.bucket_strs):
       print(f'{bs}', end='')
+      if self.bucket_cnts is not None:
+        print(f'\t{self.bucket_cnts[i]}', end='')
       for j, stat in enumerate(self.sys_stats):
         print(f'\t{fmt(stat[i])}', end='')
-        if self.bucket_details is not None:
-          sents, interval =  self.bucket_details[j][i]
+        if self.bucket_intervals is not None:
+          interval =  self.bucket_intervals[j][i]
           low, up = interval['lower_bound'], interval['upper_bound']
-          print(f' ({fmt(low)}, {fmt(up)})', end='')
-          print(f' (#sents: {sents})', end='')
+          print(f' [{fmt(low)}, {fmt(up)}]', end='')
       print()
     print()
 
@@ -476,23 +510,42 @@ class SentenceReport(Report):
     sys = self.sys_stats
     xticklabels = [s for s in self.bucketer.bucket_strs] 
 
+    if self.bucket_intervals:
+      errs = []
+      for i, stat in enumerate(sys):
+        lows, ups = [], []
+        for j, score in enumerate(stat):
+          interval = self.bucket_intervals[i][j]
+          low, up = interval['lower_bound'], interval['upper_bound']
+          lows.append(score-low)
+          ups.append(up-score)
+        errs.append(np.array([lows, ups]) )
+    else:
+      errs = None
+
     make_bar_chart(sys,
                    output_directory, output_fig_file,
                    output_fig_format=output_fig_format,
+                   errs=errs,
                    xlabel=self.bucketer.name(), ylabel=self.yname,
                    xticklabels=xticklabels)
 
   def html_content(self, output_directory=None):
-    table = [ [self.bucketer.idstr()] + sys_names ]
+    line = [self.bucketer.idstr()]
+    if self.bucket_cnts is not None:
+      line.append('# sents')
+    line += sys_names
+    table = [ line ]
     for i, bs in enumerate(self.bucketer.bucket_strs):
       line = [bs]
+      if self.bucket_cnts is not None:
+        line.append(f'\t{self.bucket_cnts[i]}')
       for j, stat in enumerate(self.sys_stats):
         line.append(fmt(stat[i]))
-        if self.bucket_details is not None:
-          sents, interval =  self.bucket_details[j][i]
+        if self.bucket_intervals is not None:
+          interval =  self.bucket_intervals[j][i]
           low, up = interval['lower_bound'], interval['upper_bound']
-          line[-1] += f' ({fmt(low)}, {fmt(up)})'
-          line[-1] += f' (#sents: {sents})'
+          line[-1] += f'<font size=2> ({fmt(low)}, {fmt(up)})</font>'
       table.extend([line])
     html = html_table(table, self.title)
     for ext in ('png', 'pdf'):


### PR DESCRIPTION
Fix #88.

Support printing the number of counts of words/sentences in each bucket and confidence intervals by setting `output_bucket_details=True`.

Example command:

`compare-mt example/ted.ref.eng example/ted.sys1.eng example/ted.sys2.eng --compare_word_accuracies bucket_type=freq,output_bucket_details=True --compare_sentence_buckets bucket_type=length,statistic_type=score,score_measure=bleu,output_bucket_details=True --output_directory out`

Output:
![image](https://user-images.githubusercontent.com/43542692/62678873-ac595980-b980-11e9-9bd1-4c0226cd61a8.png)
![image](https://user-images.githubusercontent.com/43542692/62678924-d448bd00-b980-11e9-90d7-e991ebd27430.png)
![image](https://user-images.githubusercontent.com/43542692/62678935-db6fcb00-b980-11e9-802a-dc5fab0805b9.png)

(Maybe I should find a better way to display the results.)