### PR TITLE
Improvements to latex output

### DIFF
--- a/compare_mt/formatting.py
+++ b/compare_mt/formatting.py
@@ -1,4 +1,16 @@
+import re
+
 class Formatter(object):
+    pat_square_open  = re.compile("\[")
+    pat_square_closed  = re.compile("\]")
+    pat_lt  = re.compile("<")
+    pat_gt  = re.compile(">")
+    latex_substitutions = { 
+        pat_square_open: "{[}",
+        pat_square_closed: "{]}",
+        pat_lt: r"\\textless",
+        pat_gt: r"\\textgreater"
+    }
 
     def __init__(self, decimals=4):
         self.set_decimals(decimals)
@@ -6,10 +18,18 @@ class Formatter(object):
     def set_decimals(self, decimals):
         self.decimals = decimals
     
+    def escape_latex(self, x):
+        """Adds possible escape sequences to make the input
+        LateX compatible"""
+        for pat, replace_with in self.latex_substitutions.items():
+            x = pat.sub(replace_with, x)
+        return x
+        
+    
     def __call__(self, x):
         """Convert object to string with controlled decimals"""
         if isinstance(x, str):
-            return x
+            return self.escape_latex(x)
         elif isinstance(x, int):
             return f"{x:d}"
         elif isinstance(x, float):

--- a/compare_mt/formatting.py
+++ b/compare_mt/formatting.py
@@ -1,15 +1,12 @@
 import re
 
 class Formatter(object):
-    pat_square_open  = re.compile("\[")
-    pat_square_closed  = re.compile("\]")
-    pat_lt  = re.compile("<")
-    pat_gt  = re.compile(">")
+
     latex_substitutions = {
-        pat_square_open: "{[}",
-        pat_square_closed: "{]}",
-        pat_lt: r"\\textless",
-        pat_gt: r"\\textgreater"
+        re.compile("\["): "{[}",
+        re.compile("\]"): "{]}",
+        re.compile("<"): r"\\textless",
+        re.compile(">"): r"\\textgreater"
     }
 
     def __init__(self, decimals=4):

--- a/compare_mt/formatting.py
+++ b/compare_mt/formatting.py
@@ -5,7 +5,7 @@ class Formatter(object):
     pat_square_closed  = re.compile("\]")
     pat_lt  = re.compile("<")
     pat_gt  = re.compile(">")
-    latex_substitutions = { 
+    latex_substitutions = {
         pat_square_open: "{[}",
         pat_square_closed: "{]}",
         pat_lt: r"\\textless",
@@ -19,13 +19,12 @@ class Formatter(object):
         self.decimals = decimals
     
     def escape_latex(self, x):
-        """Adds possible escape sequences to make the input
+        """Adds escape sequences wherever needed to make the output
         LateX compatible"""
         for pat, replace_with in self.latex_substitutions.items():
             x = pat.sub(replace_with, x)
         return x
-        
-    
+
     def __call__(self, x):
         """Convert object to string with controlled decimals"""
         if isinstance(x, str):

--- a/compare_mt/reporters.py
+++ b/compare_mt/reporters.py
@@ -396,7 +396,7 @@ class WordReport(Report):
         if self.examples:
           line.append(f'<a href="{self.output_fig_file}.html#bucket{i}">Examples</a>')
         table += [line] 
-      html += html_table(table, title, skip_last_col=True)
+      html += html_table(table, title, latex_ignore_cols={3})
       img_name = f'{self.output_fig_file}-{at}'
       for ext in ('png', 'pdf'):
         self.plot(output_directory, img_name, ext)
@@ -634,7 +634,7 @@ def tag_str(tag, str, new_line=''):
   return f'<{tag}>{new_line} {str} {new_line}</{tag}>'
 
 def html_table(table, title=None, bold_rows=1, bold_cols=1,
-              skip_last_col=False):
+               latex_ignore_cols={}):
   html = '<table border="1">\n'
   if title is not None:
     html += tag_str('caption', title)
@@ -651,10 +651,7 @@ def html_table(table, title=None, bold_rows=1, bold_cols=1,
     cs[bold_cols-1] = 'c||'
   latex_code += "  \\begin{tabular}{"+''.join(cs)+"}\n"
   for i, row in enumerate(table):
-    if skip_last_col:
-      latex_code += ' & '.join([fmt(x) for x in row[:-1]]) + (' \\\\\n' if i != bold_rows-1 else ' \\\\ \\hline \\hline\n')
-    else:
-      latex_code += ' & '.join([fmt(x) for x in row]) + (' \\\\\n' if i != bold_rows-1 else ' \\\\ \\hline \\hline\n')
+    latex_code += ' & '.join([fmt(x) for c_i, x in enumerate(row) if c_i not in latex_ignore_cols]) + (' \\\\\n' if i != bold_rows-1 else ' \\\\ \\hline \\hline\n')
       
   latex_code += "  \\end{tabular}\n  \\caption{Caption}\n  \\label{tab:table"+tab_id+"}\n\\end{table}"
 

--- a/compare_mt/reporters.py
+++ b/compare_mt/reporters.py
@@ -652,7 +652,6 @@ def html_table(table, title=None, bold_rows=1, bold_cols=1,
   latex_code += "  \\begin{tabular}{"+''.join(cs)+"}\n"
   for i, row in enumerate(table):
     latex_code += ' & '.join([fmt(x) for c_i, x in enumerate(row) if c_i not in latex_ignore_cols]) + (' \\\\\n' if i != bold_rows-1 else ' \\\\ \\hline \\hline\n')
-      
   latex_code += "  \\end{tabular}\n  \\caption{Caption}\n  \\label{tab:table"+tab_id+"}\n\\end{table}"
 
   html += (f'<button onclick="showhide(\'{tab_id}_latex\')">Show/Hide LaTeX</button> <br/>' +

--- a/compare_mt/reporters.py
+++ b/compare_mt/reporters.py
@@ -633,8 +633,7 @@ class SentenceExampleReport(Report):
 def tag_str(tag, str, new_line=''):
   return f'<{tag}>{new_line} {str} {new_line}</{tag}>'
 
-def html_table(table, title=None, bold_rows=1, bold_cols=1,
-               latex_ignore_cols={}):
+def html_table(table, title=None, bold_rows=1, bold_cols=1, latex_ignore_cols={}):
   html = '<table border="1">\n'
   if title is not None:
     html += tag_str('caption', title)

--- a/compare_mt/reporters.py
+++ b/compare_mt/reporters.py
@@ -396,7 +396,7 @@ class WordReport(Report):
         if self.examples:
           line.append(f'<a href="{self.output_fig_file}.html#bucket{i}">Examples</a>')
         table += [line] 
-      html += html_table(table, title)
+      html += html_table(table, title, skip_last_col=True)
       img_name = f'{self.output_fig_file}-{at}'
       for ext in ('png', 'pdf'):
         self.plot(output_directory, img_name, ext)
@@ -633,7 +633,8 @@ class SentenceExampleReport(Report):
 def tag_str(tag, str, new_line=''):
   return f'<{tag}>{new_line} {str} {new_line}</{tag}>'
 
-def html_table(table, title=None, bold_rows=1, bold_cols=1):
+def html_table(table, title=None, bold_rows=1, bold_cols=1,
+              skip_last_col=False):
   html = '<table border="1">\n'
   if title is not None:
     html += tag_str('caption', title)
@@ -650,7 +651,11 @@ def html_table(table, title=None, bold_rows=1, bold_cols=1):
     cs[bold_cols-1] = 'c||'
   latex_code += "  \\begin{tabular}{"+''.join(cs)+"}\n"
   for i, row in enumerate(table):
-    latex_code += ' & '.join([fmt(x) for x in row]) + (' \\\\\n' if i != bold_rows-1 else ' \\\\ \\hline \\hline\n')
+    if skip_last_col:
+      latex_code += ' & '.join([fmt(x) for x in row[:-1]]) + (' \\\\\n' if i != bold_rows-1 else ' \\\\ \\hline \\hline\n')
+    else:
+      latex_code += ' & '.join([fmt(x) for x in row]) + (' \\\\\n' if i != bold_rows-1 else ' \\\\ \\hline \\hline\n')
+      
   latex_code += "  \\end{tabular}\n  \\caption{Caption}\n  \\label{tab:table"+tab_id+"}\n\\end{table}"
 
   html += (f'<button onclick="showhide(\'{tab_id}_latex\')">Show/Hide LaTeX</button> <br/>' +


### PR DESCRIPTION

## Issue

The ability to directly copy + paste the latex output for various reports is one of the most useful features. However, in the case of tables, the output is not Latex compatible and thus a few edits have to be made before it can be pasted.

## Changes

1. Adding escape sequences/commands to make the output latex compatible 

Specifically:
- The square brackets are now escaped with braces (`[` is replaced with `{[}`, and `]` is replaced with`{]}`).

- The `<` and `>` symbols are replaced with `\textless` and `\textgreater` respectively.

_This change will affect all the tables._

2. Removing redundant fields

In the "word fmeas by frequency bucket" report, the third column is a link to the examples, and should not be added to the output. This PR drops the column from the output by allowing the function `html_func` to take an optional argument, `latex_ignore_cols`. The columns specified in the set `latex_ignore_cols` are not added to the latex output.

_This change will only affect the  "word fmeas by frequency bucket" table, but adds a simple mechanism to make a similar change to the other tables._

## Example

Sample outputs before and after the changes:

Before:
```latex
\begin{table}[t]
  \centering
  \begin{tabular}{c||ccc}
frequency & sys1 & sys2 & Examples \\ \hline \hline
<1 & 0.0000 & 0.0000 & Examples \\
1 & 0.3548 & 0.3552 & Examples \\
2 & 0.4440 & 0.4431 & Examples \\
3 & 0.4637 & 0.4626 & Examples \\
4 & 0.4588 & 0.4623 & Examples \\
[5,10) & 0.5306 & 0.5346 & Examples \\
[10,100) & 0.5733 & 0.5759 & Examples \\
[100,1000) & 0.6055 & 0.6070 & Examples \\
>=1000 & 0.7483 & 0.7502 & Examples \\
  \end{tabular}
  \caption{Caption}
  \label{tab:table123}
\end{table}
```

After (doesn't have the extra column, can be directly copy pasted):

```latex
\begin{table}[t]
  \centering
  \begin{tabular}{c||ccc}
frequency & sys1 & sys2 \\ \hline \hline
\textless1 & 0.0000 & 0.0000 \\
1 & 0.3548 & 0.3552 \\
2 & 0.4440 & 0.4431 \\
3 & 0.4637 & 0.4626 \\
4 & 0.4588 & 0.4623 \\
{[}5,10) & 0.5306 & 0.5346 \\
{[}10,100) & 0.5733 & 0.5759 \\
{[}100,1000) & 0.6055 & 0.6070 \\
\textgreater=1000 & 0.7483 & 0.7502 \\
  \end{tabular}
  \caption{Caption}
  \label{tab:table123}
\end{table}
```

## Tests

A number of examples were tested manually to make sure the change is limited to the the description above. The changes in this PR do not break any of the tests in the `tests` folder.