### PR TITLE
Option to launch http server to view reports

### DIFF
--- a/compare_mt/__init__.py
+++ b/compare_mt/__init__.py
@@ -8,5 +8,4 @@ import compare_mt.reporters
 import compare_mt.arg_utils
 import compare_mt.print_utils
 
-
-__version__ = "0.2.7"
+__version__ = "0.2.8"

--- a/compare_mt/compare_mt_main.py
+++ b/compare_mt/compare_mt_main.py
@@ -658,7 +658,7 @@ def main():
   if args.bind_port:
     out_dir = args.output_directory
     if not out_dir:
-      out_dir = str(tempfile.TemporaryDirectory())
+      out_dir = tempfile.TemporaryDirectory().name
       reporters.generate_html_report(reports, out_dir, args.report_title)
     reporters.launch_http_server(out_dir, bind_port=args.bind_port)
 

--- a/compare_mt/reporters.py
+++ b/compare_mt/reporters.py
@@ -8,7 +8,7 @@ import itertools
 from compare_mt.formatting import fmt
 
 from functools import partial
-from http.server import SimpleHTTPRequestHandler, ThreadingHTTPServer
+from http.server import SimpleHTTPRequestHandler, HTTPServer
 import socket
 from pathlib import Path
 import logging as log
@@ -694,7 +694,7 @@ def launch_http_server(output_directory: str, bind_address:str ='0.0.0.0', bind_
   log.info(f'Directory = {output_directory}')
   log.info(f'Launching a web server:: http://{hostname}:{bind_port}/')
   Handler = partial(SimpleHTTPRequestHandler, directory=output_directory)
-  server = ThreadingHTTPServer(server_address=(bind_address, bind_port),
+  server = HTTPServer(server_address=(bind_address, bind_port),
                                RequestHandlerClass=Handler)
   try:
     server.serve_forever()

--- a/compare_mt/reporters.py
+++ b/compare_mt/reporters.py
@@ -7,6 +7,14 @@ import os
 import itertools
 from compare_mt.formatting import fmt
 
+from functools import partial
+from http.server import SimpleHTTPRequestHandler, ThreadingHTTPServer
+import socket
+from pathlib import Path
+import logging as log
+
+log.basicConfig(level=log.INFO)
+
 # Global variables used by all reporters. These are set by compare_mt_main.py
 sys_names = None
 fig_size = None
@@ -679,4 +687,17 @@ def generate_html_report(reports, output_directory, report_title):
   css_file = os.path.join(output_directory, 'compare_mt.css')
   with open(css_file, 'w') as f:
     f.write(css_style)
+
+def launch_http_server(output_directory: str, bind_address:str ='0.0.0.0', bind_port: int=8000):
+  assert Path(output_directory).is_dir()
+  hostname = bind_address if bind_address != '0.0.0.0' else socket.gethostname()
+  log.info(f'Directory = {output_directory}')
+  log.info(f'Launching a web server:: http://{hostname}:{bind_port}/')
+  Handler = partial(SimpleHTTPRequestHandler, directory=output_directory)
+  server = ThreadingHTTPServer(server_address=(bind_address, bind_port),
+                               RequestHandlerClass=Handler)
+  try:
+    server.serve_forever()
+  except KeyboardInterrupt:
+    pass # all good! Exiting without printing stacktrace
   

--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,7 @@
 from setuptools import setup, find_packages
 import unittest
 import codecs
-import re
-import os
-
+import compare_mt
 
 def test_suite():
   test_loader = unittest.TestLoader()
@@ -12,21 +10,10 @@ def test_suite():
   return test_suite
 
 
-def find_version():
-  """Find version in compare_mt/__init__.py"""
-  here = os.path.abspath(os.path.dirname(__file__))
-  with codecs.open(os.path.join(here, "compare_mt", "__init__.py"), 'r') as fp:
-    version_file = fp.read()
-    version_match = re.search(
-      r"^__version__ = ['\"]([^'\"]*)['\"]", version_file, re.M)
-    if version_match:
-        return version_match.group(1)
-  raise RuntimeError("Unable to find version string.")
-
 
 setup(
   name="compare_mt",
-  version=find_version(),
+  version=compare_mt.__version__,
   description="Holistic comparison of the output of text generation models",
   long_description=codecs.open("README.md", encoding="utf-8").read(),
   long_description_content_type="text/markdown",


### PR DESCRIPTION
- Added `--http [PORT_NUM]` option. Disabled by default. When specified, it automatically launches HTTP Server. for example `-http 8000`
- Respects `--output_directory` and reuses it when available. When `output_directory` is not available, it creates a temporary dir that gets auto removed when server process is shutdown

Maybe this was not needed, but ...
- updated the version 0.2.7 -> 0.2.8 (while doing that, I couldn't resist simplification of the `find_version`)

P.S.
thanks for creating this awesome tool 🙏  and 👏🏼 from USC ISI 