### PR TITLE
call Scorer.cache_stats with src to align with the signature

### DIFF
--- a/compare_mt/compare_mt_main.py
+++ b/compare_mt/compare_mt_main.py
@@ -64,7 +64,7 @@ def generate_score_report(
     scores, strs = zip(*[scorer.score_corpus(ref, out, src=src) for out in outs])
   
   if to_cache:
-    cache_dict = cache_utils.return_cache_dict(cache_key_list, [scores, strs, [scorer.cache_stats(ref, outs[0])] ])
+    cache_dict = cache_utils.return_cache_dict(cache_key_list, [scores, strs, [scorer.cache_stats(ref, outs[0], src=src)] ])
     return cache_dict
 
   if bootstrap != 0:
@@ -72,7 +72,7 @@ def generate_score_report(
     for i in range(len(scores)):
       for j in range(i+1, len(scores)):
         direcs.append( (i,j) )
-    wins, sys_stats = sign_utils.eval_with_paired_bootstrap(ref, outs, scorer, direcs, num_samples=bootstrap, cache_stats=sign_stats)
+    wins, sys_stats = sign_utils.eval_with_paired_bootstrap(ref, outs, src, scorer, direcs, num_samples=bootstrap, cache_stats=sign_stats)
     wins = list(zip(direcs, wins))
   else:
     wins = sys_stats = None
@@ -348,7 +348,7 @@ def generate_sentence_bucketed_report(ref, outs, src=None,
 
   if output_bucket_details and statistic_type == 'score':
     bucket_cnt_calculator = lambda out,ref,src: len(out)
-    bucket_interval_calculator = lambda out,ref: sign_utils.eval_with_paired_bootstrap(ref, [out], scorer, None)[1][0]
+    bucket_interval_calculator = lambda out,ref: sign_utils.eval_with_paired_bootstrap(ref, [out], src, scorer, None)[1][0]
     if cache_dicts is not None: # we don't cache bcs
       bcs = [bucketer.create_bucketed_corpus(out, ref=ref, src=src,ref_labels=ref_labels if ref_labels else None, out_labels=out_labels[i] if out_labels else None) for i, out in enumerate(outs)]
     bucket_cnts = [bucket_cnt_calculator(out,ref,src) for (out,ref,src) in bcs[0]]

--- a/compare_mt/scorers.py
+++ b/compare_mt/scorers.py
@@ -1020,7 +1020,7 @@ class GleuScorer(Scorer):
       cached_stats: A list of cached statistics
 
     Returns:
-      A tuple containing a single value for the BLEU score and a string summarizing auxiliary information
+      A tuple containing a single value for the GLEU score and a string summarizing auxiliary information
     """
     if len(cached_stats) == 0:
       return 0.0, None

--- a/compare_mt/sign_utils.py
+++ b/compare_mt/sign_utils.py
@@ -13,7 +13,7 @@
 import numpy as np
 
 
-def eval_with_paired_bootstrap(ref, outs,
+def eval_with_paired_bootstrap(ref, outs, src,
                                scorer,
                                compare_directions=[(0, 1)],
                                num_samples=1000, sample_ratio=0.5,
@@ -26,6 +26,7 @@ def eval_with_paired_bootstrap(ref, outs,
   Args:
     ref: The correct labels
     outs: The output of systems
+    src: The source corpus
     scorer: The scorer
     compare_directions: A string specifying which two systems to compare
     num_samples: The number of bootstrap samples to take
@@ -41,7 +42,7 @@ def eval_with_paired_bootstrap(ref, outs,
   ids = list(range(n))
 
   if cache_stats is None:
-    cache_stats = [scorer.cache_stats(ref, out) for out in outs] 
+    cache_stats = [scorer.cache_stats(ref, out, src=src) for out in outs]
   sample_size = int(n*sample_ratio)
   for _ in range(num_samples):
     # Subsample the gold and system outputs (with replacement)
@@ -52,7 +53,8 @@ def eval_with_paired_bootstrap(ref, outs,
     else:
       reduced_ref = [ref[i] for i in reduced_ids]
       reduced_outs = [[out[i] for i in reduced_ids] for out in outs]
-      sys_score, _ = zip(*[scorer.score_corpus(reduced_ref, reduced_out) for reduced_out in reduced_outs])
+      reduced_src = [src[i] for i in reduced_ids]
+      sys_score, _ = zip(*[scorer.score_corpus(reduced_ref, reduced_out, reduced_src) for reduced_out in reduced_outs])
 
     if wins is not None:
       for i, compare_direction in enumerate(compare_directions): 


### PR DESCRIPTION
`src` is necessary for the `cache_stats` functions of several scorers.