### PR TITLE
Fix bar chart color cycling

### DIFF
--- a/compare_mt/reporters.py
+++ b/compare_mt/reporters.py
@@ -1,7 +1,9 @@
 import matplotlib
 matplotlib.use('agg')
-from matplotlib import pyplot as plt 
+from matplotlib import pyplot as plt
+from cycler import cycler
 plt.rcParams['font.family'] = 'sans-serif'
+plt.rcParams['axes.prop_cycle'] = cycler(color=["#7293CB", "#E1974C", "#84BA5B", "#D35E60", "#808585", "#9067A7", "#AB6857", "#CCC210"])
 import numpy as np
 import os
 import itertools
@@ -78,8 +80,6 @@ def next_tab_id():
   tab_counter += 1
   return f'{tab_counter:03d}'
 
-bar_colors = ["#7293CB", "#E1974C", "#84BA5B", "#D35E60", "#808585", "#9067A7", "#AB6857", "#CCC210"]
-
 def make_bar_chart(datas,
                    output_directory, output_fig_file, output_fig_format='png',
                    errs=None, title=None, xlabel=None, xticklabels=None, ylabel=None):
@@ -89,7 +89,7 @@ def make_bar_chart(datas,
   bars = []
   for i, data in enumerate(datas):
     err = errs[i] if errs != None else None
-    bars.append(ax.bar(ind+i*width, data, width, color=bar_colors[i], bottom=0, yerr=err))
+    bars.append(ax.bar(ind+i*width, data, width, bottom=0, yerr=err))
   # Set axis/title labels
   if title is not None:
     ax.set_title(title)


### PR DESCRIPTION
Indexing into a hardcoded list of colors for bar charts causes an IndexError when the number of systems being compared is greater than the number of colors in `bar_colors`.
https://github.com/neulab/compare-mt/blob/a0482d7a3ddac64ef51c3c92a0c86919c63f670b/compare_mt/reporters.py#L81-L92

I think the right way to handle this is to use matplotlib's `rcParams` to customize the color cycle instead.

This does result in duplicate colors in the legend when there are >8 systems, but that's probably better than crashing.